### PR TITLE
Add pack voltage thresholds

### DIFF
--- a/src/daly.cpp
+++ b/src/daly.cpp
@@ -98,6 +98,11 @@ bool DalyBms::loop()
         case 10:
             if (!getStaticData)
                 requestCounter = getVoltageThreshold() ? (requestCounter + 1) : 0;
+            requestCallback();
+            break;
+        case 11:
+            if (!getStaticData)
+                requestCounter = getPackVoltageThreshold() ? (requestCounter + 1) : 0;
             requestCounter = 0;
             requestCallback();
             getStaticData = true;
@@ -124,6 +129,23 @@ bool DalyBms::getVoltageThreshold() // 0x59
     get.maxCellThreshold2 = (float)((this->frameBuff[0][6] << 8) | this->frameBuff[0][7]);
     get.minCellThreshold1 = (float)((this->frameBuff[0][8] << 8) | this->frameBuff[0][9]);
     get.minCellThreshold2 = (float)((this->frameBuff[0][10] << 8) | this->frameBuff[0][11]);
+
+    return true;
+}
+
+bool DalyBms::getPackVoltageThreshold() // 0x5A
+{
+    if (!this->requestData(COMMAND::PACK_THRESHOLDS, 1))
+    {
+        BMS_DEBUG_PRINT("<DALY-BMS DEBUG> Receive failed, min/max pack voltage thresholds won't be modified!\n");
+        BMS_DEBUG_WEB("<DALY-BMS DEBUG> Receive failed, min/max pack voltage thresholds won't be modified!\n");
+        return false;
+    }
+
+    get.maxPackThreshold1 = (float)((this->frameBuff[0][4] << 8) | this->frameBuff[0][5]);
+    get.maxPackThreshold2 = (float)((this->frameBuff[0][6] << 8) | this->frameBuff[0][7]);
+    get.minPackThreshold1 = (float)((this->frameBuff[0][8] << 8) | this->frameBuff[0][9]);
+    get.minPackThreshold2 = (float)((this->frameBuff[0][10] << 8) | this->frameBuff[0][11]);
 
     return true;
 }

--- a/src/daly.h
+++ b/src/daly.h
@@ -64,6 +64,7 @@ public:
     enum COMMAND
     {
         CELL_THRESHOLDS = 0x59,
+        PACK_THRESHOLDS = 0x5A,
         VOUT_IOUT_SOC = 0x90,
         MIN_MAX_CELL_VOLTAGE = 0x91,
         MIN_MAX_TEMPERATURE = 0x92,
@@ -92,6 +93,12 @@ public:
         float minCellThreshold1; // Level-1 alarm threshold for low Voltage in Millivolts
         float maxCellThreshold2; // Level-2 alarm threshold for High Voltage in Millivolts
         float minCellThreshold2; // Level-2 alarm threshold for low Voltage in Millivolts
+
+        // data from 0x5A
+        float maxPackThreshold1; // Level-1 alarm threshold for high voltage in decivolts
+        float minPackThreshold1; // Level-1 alarm threshold for low voltage in decivolts
+        float maxPackThreshold2; // Level-2 alarm threshold for high voltage in decivolts
+        float minPackThreshold2; // Level-2 alarm threshold for low voltage in decivolts
 
         // data from 0x90
         float packVoltage; // pressure (0.1 V)
@@ -252,6 +259,12 @@ public:
      * @return True on successful aquisition, false otherwise
      */
     bool getVoltageThreshold();
+
+    /**
+     * @brief Gets pack voltage thresholds
+     * @return True on successful aquisition, false otherwise
+     */
+    bool getPackVoltageThreshold();
 
     /**
      * @brief Gets the pack temperature from the min and max of all the available temperature sensors

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -740,6 +740,12 @@ void getJsonData()
   packJson[F("Cell_Temp")] = bms.get.cellTemperature[0];
   packJson[F("cell_hVt")] = bms.get.maxCellThreshold1 / 1000;
   packJson[F("cell_lVt")] = bms.get.minCellThreshold1 / 1000;
+  packJson[F("cell_hVt2")] = bms.get.maxCellThreshold2 / 1000;
+  packJson[F("cell_lVt2")] = bms.get.minCellThreshold2 / 1000;
+  packJson[F("pack_hVt")] = bms.get.maxPackThreshold1 / 10;
+  packJson[F("pack_lVt")] = bms.get.minPackThreshold1 / 10;
+  packJson[F("pack_hVt2")] = bms.get.maxPackThreshold2 / 10;
+  packJson[F("pack_lVt2")] = bms.get.minPackThreshold2 / 10;
   packJson[F("High_CellNr")] = bms.get.maxCellVNum;
   packJson[F("High_CellV")] = bms.get.maxCellmV / 1000;
   packJson[F("Low_CellNr")] = bms.get.minCellVNum;


### PR DESCRIPTION
I would like to contribute a little to this excellent project.

I am currently missing the setting of the BMS configuration as well as the support of the active balancer (must admit, I have not tried it). I will open a few pull requests over a longer period of time to add these features.


This PR is used to get the voltage thresholds for the pack and publish them via MQTT.

The level-2 values for the cell voltage thresholds are also published via MQTT. 
I noticed that the level-2 values are the values I set via the SmartBMS app.


`cell_hVt` and `cell_lVt` remains unchanged.

```
...
      "cell_hVt": 4.15,
      "cell_lVt": 2.8,
      "cell_hVt2": 3.55,
      "cell_lVt2": 2.8,
      "pack_hVt": 66.4,
      "pack_lVt": 44.8,
      "pack_hVt2": 56,
      "pack_lVt2": 47,
...
```

